### PR TITLE
Fix ai.giistech.club

### DIFF
--- a/giistech.club.yaml
+++ b/giistech.club.yaml
@@ -149,5 +149,5 @@ ai:
   value: ai-router.fly.dev.
   octodns:
     cloudflare:
-      proxied: true
+      proxied: false
       auto_ttl: true


### PR DESCRIPTION
Since fly.io is issuing a certificate themselves, I've removed proxying from Cloudflare since we don't NEED the Cloudflare features